### PR TITLE
Fix delete_scheduled!

### DIFF
--- a/src/Overseer.jl
+++ b/src/Overseer.jl
@@ -31,5 +31,5 @@ module Overseer
     export prepare, singleton, valid_entities, groups, group, create_group!, regroup!, remove_group!
 
     # Components
-    export swap!
+    export swap_order!
 end # module

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -326,18 +326,18 @@ function expand_indices_bool(expr)
     return expr, sets, orsets
 end
 
-Base.@propagate_inbounds function swap!(ids::Indices, from_page::Page, to_page::Page, packed_id1::Int, packed_id2::Int)
+Base.@propagate_inbounds function swap_order!(ids::Indices, from_page::Page, to_page::Page, packed_id1::Int, packed_id2::Int)
     ids.reverse[from_page.id][from_page.offset] = packed_id2
     ids.reverse[to_page.id][to_page.offset]     = packed_id1
     ids.packed[packed_id1], ids.packed[packed_id2] =
         ids.packed[packed_id2], ids.packed[packed_id1]
 end
 
-Base.@propagate_inbounds function swap!(ids::Indices, reverse_id1::Int, reverse_id2::Int)
+Base.@propagate_inbounds function swap_order!(ids::Indices, reverse_id1::Int, reverse_id2::Int)
     from_page = pageid_offset(ids, reverse_id1)
     to_page = pageid_offset(ids, reverse_id2)
     packed_id1 = ids[from_page]
     packed_id2 = ids[to_page]
-    swap!(ids, from_page, to_page, packed_id1, packed_id2)
+    swap_order!(ids, from_page, to_page, packed_id1, packed_id2)
     return packed_id1, packed_id2
 end

--- a/src/ledger.jl
+++ b/src/ledger.jl
@@ -256,6 +256,7 @@ function delete_scheduled!(m::AbstractLedger)
 		entities(m)[e.id] = EMPTY_ENTITY
 		push!(free_entities(m), e)
 	end
+	empty!(to_delete(m))
 end
 
 function update(s::Stage, m::AbstractLedger)

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -102,7 +102,7 @@ empty!(c3)
 @test isempty(c3)
 
 
-# swap_orderping
+# swap_ordering
 c2[Entity(12)] = Test2()
 
 @test_throws BoundsError swap_order!(c2, Entity(14), Entity(15))

--- a/test/test_ledger.jl
+++ b/test/test_ledger.jl
@@ -67,6 +67,13 @@ delete_scheduled!(m)
 
 @test length(m[T4]) == 3
 
+# Ensure delete_scheduled!() does nothing when no entities are scheduled for
+# deletion, but some of the old ids have been recycled
+for _ = 5:10
+    Entity(m, T4())
+end
+delete_scheduled!(m)
+@test length(m[T4]) == 9
 
 empty!(m)
 @test isempty(m.entities)


### PR DESCRIPTION
I found that `delete_scheduled!` didn't empty the pending deletion list. This bug caused recycled entities to be deleted when `delete_scheduled!` was called multiple times.

I also fixed `swap_order!` (completing an old renaming) to get the tests passing again.