### PR TITLE
Fixes for EntityIterator and IndicesIterator

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -199,9 +199,11 @@ struct EntityIterator{T <: Union{IndicesIterator,Indices,AbstractGroup}}
     it::T
 end
 
+Base.eltype(::EntityIterator) = Entity
+Base.IteratorSize(i::EntityIterator) = Base.IteratorSize(i.it)
 Base.length(i::EntityIterator) = length(i.it)
 
-@inline function Base.iterate(i::EntityIterator, state = 1)
+function Base.iterate(i::EntityIterator, state = 1)
     n = iterate(i.it, state)
     n === nothing && return n
     return Entity(n[1]), n[2]
@@ -232,7 +234,7 @@ macro entities_in(indices_expr)
             else
                 shortest = t_shortest
             end
-            Overseer.EntityIterator(Overseer.IndicesIterator(shortest, x->$expr, length(shortest)))
+            Overseer.EntityIterator(Overseer.IndicesIterator(shortest, x->$expr))
         end)
     end
 end

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -242,15 +242,14 @@ end
 struct IndicesIterator{I, T<:Function}
     shortest::I
     test::T
-    len::Int
 end
 
-Base.length(it::IndicesIterator) = it.len
+Base.IteratorSize(::IndicesIterator) = Base.SizeUnknown()
 
 @inline indices(i::Indices) = i
 
 @inline function Base.iterate(it::IndicesIterator, state=1)
-    it_length = length(it)
+    it_length = length(it.shortest)
     for i=state:it_length
         id = indices(it.shortest).packed[i]
         if it.test(id)
@@ -280,7 +279,7 @@ macro indices_in(indices_expr)
         else
             shortest = t_shortest
         end
-        Overseer.IndicesIterator(shortest, x -> $expr, length(shortest))
+        Overseer.IndicesIterator(shortest, x -> $expr)
     end)
 end
 

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -139,3 +139,21 @@ swap_order!(c3, Entity(12), Entity(13))
 
 @test c3.indices[13] == orig_id1
 @test c3.indices[12] == orig_id2
+
+# Issue 4: collect() and iterator length
+@testset "collect" begin
+    e1 = Entity(1)
+    e2 = Entity(2)
+    e3 = Entity(3)
+
+    comp1 = Overseer.component_type(Test1){Test1}()
+    comp2 = Overseer.component_type(Test2){Test2}()
+    comp1[e1] = Test1(1)
+    comp1[e2] = Test1(1); comp2[e2] = Test2(1)
+    comp2[e3] = Test2(1)
+
+    iter = @entities_in(comp1 && comp2)
+    es = collect(iter)
+    @test es == [e2]
+    @test eltype(es) == Entity
+end


### PR DESCRIPTION
* IteratorSize(::IndicesIterator) set to SizeUnknown, as it involves a
  predicate which filters out an unknown number of elements.
* IteratorSize(::EntityIterator) defers to the wrapped iterator
* Implement eltype(::EntityIterator) so that collect() is type stable

Fixes #4 