### PR TITLE
Implement new entity iteration scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ julia = "^1"
 [extras]
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
-test = ["Test", "Parameters"]
+test = ["Test", "Parameters", "BenchmarkTools"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ end
 	axis::Vec3{Float64}
 end
 ```
-One thing to remember is that for now components can not have type parameters. 
 Next we define our systems.
 
 ```julia
@@ -64,32 +63,23 @@ struct Oscillator <: System end
 Overseer.requested_components(::Oscillator) = (Spatial, Spring)
 
 function Overseer.update(::Oscillator, m::AbstractLedger)
-	spatial = m[Spatial]
-	spring = m[Spring]
-	for e in @entities_in(spatial && spring)
-		e_spat  = spatial[e]
-		spr     = spring[e]
-		v_prev  = e_spat.velocity 
-		new_v   = v_prev - (e_spat.position - spr.center) * spr.spring_constant
-		spatial[e] = Spatial(e_spat.position, new_v)
+	for e in @entities_in(m, Spatial && Spring)
+		new_v   = e.velocity - (e.position - e.center) * e.spring_constant
+		e[Spatial] = Spatial(e.position, new_v)
 	end
 end
 
 struct Rotator <: System  end
 Overseer.requested_components(::Rotator) = (Spatial, Rotation)
 
-function Overseer.update(::Rotator, dio::AbstractLedger)
-	rotation  = dio[Rotation]
-	spatial   = dio[Spatial]
+function Overseer.update(::Rotator, m::AbstractLedger)
 	dt = 0.01
-	for e in @entities_in(rotation && spatial) 
-    	e_rotation = rotation[e]
-    	e_spatial  = spatial[e]
-		n          = e_rotation.axis
-		r          = - e_rotation.center + e_spatial.position
-		theta      = e_rotation.omega * dt
+	for e in @entities_in(m, Rotation && Spatial) 
+		n          = e.axis
+		r          = - e.center + e.position
+		theta      = e.omega * dt
 		nnd        = n * dot(n, r)
-		spatial[e] = Spatial(Point3f0(e_rotation.center + nnd + (r - nnd) * cos(theta) + cross(r, n) * sin(theta)), e_spatial.velocity)
+		e[Spatial] = Spatial(Point3f0(e.center + nnd + (r - nnd) * cos(theta) + cross(r, n) * sin(theta)), e.velocity)
 	end
 end
 
@@ -110,8 +100,11 @@ As we can see the oscillator will cause the velocity to be inwards towards the c
 the rotator causes just a rotation around an axis with a given rotational velocity, and the mover updates the positions 
 given the velocity.
 
-Each system iterates over the entities that have the components like given to the rules for `@entities_in`. For example 
-`@entities_in(a && b || c && !d)` will iterate through all the entities that are in component `a` and `b` or `c` but not in `d`. 
+Each system iterates over the entities that have the components like given to the rules for `@entities_in`. 
+There are two ways of using this, either in the form `@entities_in(ledger, ComponentData1 && Componentdata2)` or 
+`@entities_in(comp1 && comp2)` where `comp1 = m[ComponentData1]`,`comp2 = m[ComponentData2]`. 
+Rules can be given in the form of `@entities_in(a && (b || c) && !d)`, which will iterate through 
+all the entities that are in component `a` and `b` or `c` but not in `d`. 
 
 Now we group these systems in a `:simulation` stage, construct a `Ledger` which is a basic `AbstractLedger` and generate some entities. 
 ```julia

--- a/src/Overseer.jl
+++ b/src/Overseer.jl
@@ -14,6 +14,8 @@ module Overseer
         points towards the fields needed for functionality (see ledger.jl for more info).
     """
     abstract type AbstractLedger end
+    
+    abstract type AbstractEntity end
 
     include("utils.jl")
     include("indices.jl")

--- a/src/component.jl
+++ b/src/component.jl
@@ -192,6 +192,10 @@ end
     id = findfirst(x -> eltype(x) == T, Tup.parameters)
     return :(unsafe_load(@inbounds getindex(t, $id))::T)
 end
+@generated function Base.setindex!(t::Tup, x::T, ::Type{T}) where {Tup <: Tuple, T<:ComponentData}
+    id = findfirst(x -> eltype(x) == T, Tup.parameters)
+    return :(unsafe_store!(getindex(t, $id), x))
+end
 ########################################
 #                                      #
 #            Iteration                 #

--- a/src/component.jl
+++ b/src/component.jl
@@ -331,7 +331,10 @@ macro entities_in(ledger, indices_expr)
     t_orsets = map(x -> comp_sym_map[x], t_orsets)
     
     if length(t_sets) == 1 && isempty(t_orsets) && expr.args[2] isa Symbol
-        return esc(:(Overseer.EntityIterator(Overseer.indices_iterator($(t_sets[1])), ($(t_sets[1]),))))
+        return esc(quote
+            $t_comp_defs
+            Overseer.EntityIterator(Overseer.indices_iterator($(t_sets[1])), ($(t_sets[1]),))
+        end)
     else
         return esc(quote
             $t_comp_defs

--- a/src/component.jl
+++ b/src/component.jl
@@ -227,7 +227,7 @@ end
 
 @generated function Base.eltype(::EntityIterator{T, TT}) where {T, TT}
     t = map(x->Ptr{eltype(x)}, TT.parameters)
-    return :(EntityState{Tuple{$t...}})
+    return :(EntityState{Tuple{$(t...)}})
 end
     
 Base.IteratorSize(i::EntityIterator) = Base.IteratorSize(i.it)
@@ -508,4 +508,3 @@ function _shared_component(typedef, mod)
        	Overseer.component_type(::Type{$tn}) = Overseer.SharedComponent
     end
 end
-

--- a/src/entity.jl
+++ b/src/entity.jl
@@ -1,4 +1,4 @@
-struct Entity
+struct Entity <: AbstractEntity
     id::Int
 end
 

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -1,5 +1,6 @@
 #Almost exact copy of the sparse_int_set in DataStructures.jl
 const INT_PER_PAGE = div(ccall(:jl_getpagesize, Clong, ()), sizeof(Int))
+const INT_PER_PAGE_1 = INT_PER_PAGE - 1
 # we use this to mark pages not in use, it must never be written to.
 const NULL_INT_PAGE = Vector{Int}()
 
@@ -48,45 +49,49 @@ end
 
 Base.lastindex(s::Indices) = s.packed[end]
 
-function pageid_offset(s::Indices, i)
-    pageid = div(i - 1, INT_PER_PAGE) + 1
-    return (id = pageid, offset = (i - 1) & (INT_PER_PAGE - 1) + 1)
+@inline function pageid_offset(i)
+    t1 = i - 1
+    pageid = div(t1, INT_PER_PAGE)
+    t2 = t1 & INT_PER_PAGE_1
+    return (id = pageid + 1, offset = t2 + 1)
 end
 
 @inline function Base.in(i, s::Indices)
-    pageid, offset = pageid_offset(s, i)
-    if pageid > length(s.reverse)
+    pageid, offset = pageid_offset(i)
+    rev = s.reverse
+    if pageid > length(rev)
         return false
     else
-        page = @inbounds s.reverse[pageid]
-        return page !== NULL_INT_PAGE &&  @inbounds page[offset] != 0
+        page = @inbounds rev[pageid]
+        return page !== NULL_INT_PAGE && @inbounds page[offset] != 0
     end
 end
 
 Base.length(s::Indices) = length(s.packed)
 
-@inline function Base.getindex(s::Indices, p::Page)
-    @boundscheck if p.id > length(s.reverse)
+Base.@propagate_inbounds @inline function Base.getindex(s::Indices, p::Page)
+    id, offset = p
+    @boundscheck if id > length(s.reverse)
         throw(BoundsError(s, p))
     end
-    page = @inbounds s.reverse[p.id]
+    page = @inbounds s.reverse[id]
 
     @boundscheck if page === NULL_INT_PAGE
         throw(BoundsError(s, p))
     end
-    id = @inbounds page[p.offset]
-    @boundscheck if id === 0
+    i = @inbounds page[offset]
+    @boundscheck if i === 0
         throw(BoundsError(s, p))
     end
-    return id 
+    return i 
 end
 
-@inline Base.getindex(s::Indices, i::Integer) = getindex(s, pageid_offset(s, i))
+Base.@propagate_inbounds @inline Base.getindex(s::Indices, i::Integer) = getindex(s, pageid_offset(i))
 
 @inline function Base.push!(s::Indices, i::Integer)
     i <= 0 && throw(DomainError("Only positive Ints allowed."))
 
-    pageid, offset = pageid_offset(s, i)
+    pageid, offset = pageid_offset(i)
     pages = s.reverse
     plen = length(pages)
 
@@ -126,7 +131,7 @@ end
         throw(ArgumentError("Cannot pop an empty set."))
     end
     id = pop!(s.packed)
-    pageid, offset = pageid_offset(s, id)
+    pageid, offset = pageid_offset(id)
     @inbounds s.reverse[pageid][offset] = 0
     @inbounds s.counters[pageid] -= 1
     cleanup!(s, pageid)
@@ -141,8 +146,8 @@ end
     end
     @inbounds begin
         packed_endid = s.packed[end]
-        from_page, from_offset = pageid_offset(s, id)
-        to_page, to_offset = pageid_offset(s, packed_endid)
+        from_page, from_offset = pageid_offset(id)
+        to_page, to_offset = pageid_offset(packed_endid)
 
         packed_id = s.reverse[from_page][from_offset]
         s.packed[packed_id] = packed_endid
@@ -220,7 +225,7 @@ Base.:(<)(a::Indices, b::Indices) = ( a<=b ) && !isequal(a, b)
 Base.:(<=)(a::Indices, b::Indices) = issubset(a, b)
 
 function findfirst_packed_id(i, s::Indices)
-    pageid, offset = pageid_offset(s, i)
+    pageid, offset = pageid_offset(i)
     if pageid > length(s.counters) || s.counters[pageid] == 0
         return 0
     end
@@ -234,7 +239,7 @@ function Base.permute!(s::Indices, p)
     permute!(s.packed)
     @inbounds for (i, eid) in s.packed
         p[i] == i && continue #nothing was changed
-        pageid, offset = pageid_offset(s, eid)
+        pageid, offset = pageid_offset(eid)
         s.reverse[page][offset] = i
     end
 end
@@ -284,7 +289,7 @@ macro indices_in(indices_expr)
 end
 
 function expand_indices_bool(expr)
-    if expr isa Symbol || expr.head == :ref || (expr.head == :call && expr.args[1] != :!)
+    if expr isa Symbol || expr.head == :ref || expr.head == :curly || (expr.head == :call && expr.args[1] != :!)
         return Expr(:call, :in, :x, expr), [expr], Symbol[]
     end
     # if !in(expr.head, (:||, :&&)) && !(expr.head == :call && expr.args[1] in == :!)
@@ -333,8 +338,8 @@ Base.@propagate_inbounds function swap_order!(ids::Indices, from_page::Page, to_
 end
 
 Base.@propagate_inbounds function swap_order!(ids::Indices, reverse_id1::Int, reverse_id2::Int)
-    from_page = pageid_offset(ids, reverse_id1)
-    to_page = pageid_offset(ids, reverse_id2)
+    from_page = pageid_offset(reverse_id1)
+    to_page = pageid_offset(reverse_id2)
     packed_id1 = ids[from_page]
     packed_id2 = ids[to_page]
     swap_order!(ids, from_page, to_page, packed_id1, packed_id2)

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -50,10 +50,14 @@ end
 Base.lastindex(s::Indices) = s.packed[end]
 
 @inline function pageid_offset(i)
-    t1 = i - 1
-    pageid = div(t1, INT_PER_PAGE)
-    t2 = t1 & INT_PER_PAGE_1
-    return (id = pageid + 1, offset = t2 + 1)
+    if INT_PER_PAGE & (INT_PER_PAGE - 1) === 0   
+        t1 = i - 1
+        pageid = div(t1, INT_PER_PAGE)
+        t2 = t1 & INT_PER_PAGE_1
+        return (id = pageid + 1, offset = t2 + 1)
+    else
+        return NamedTuple{(:id, :offset)}(divrem(i - 1, INT_PER_PAGE) .+ 1 )
+    end
 end
 
 @inline function Base.in(i, s::Indices)

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -260,7 +260,7 @@ Base.IteratorSize(::IndicesIterator) = Base.SizeUnknown()
 @inline function Base.iterate(it::IndicesIterator, state=1)
     it_length = length(it.shortest)
     for i=state:it_length
-        id = indices(it.shortest).packed[i]
+        @inbounds id = indices(it.shortest).packed[i]
         if it.test(id)
             return id, i+1
         end

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -11,7 +11,7 @@ end
     spring_constant::Float64
 end
 
-@component struct Rotation
+@component mutable struct Rotation
 	omega::Float64
 	center::NTuple{3, Float64}
 	axis::NTuple{3, Float64}

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -108,11 +108,11 @@ function update_new(::Rotator, m::AbstractLedger)
 	dt = 0.01
 	@inbounds for e in @entities_in(m, Rotation && Spatial) 
 		n          = e.axis
-		r          = e.position .- e[Rotation].center 
+		r          = e.position .- e.center 
 		theta      = e.omega * dt
 		nnd        = n .* sum(n .* r)
 		t = (r[2] * n[3] - r[3] * n[2], r[3]*n[1] - r[1] * n[3] , r[1] * n[2] - r[2] * n[1])
-		e[Spatial] = Spatial(e[Rotation].center .+ nnd .+ (r .- nnd) .* cos(theta) .+ t .* sin(theta), e.velocity)
+		e[Spatial] = Spatial(e.center .+ nnd .+ (r .- nnd) .* cos(theta) .+ t .* sin(theta), e.velocity)
 	end
 end
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,136 @@
+using BenchmarkTools
+using Parameters
+
+@component @with_kw struct Spatial
+    position::NTuple{3, Float64} = (1.0,1.0,1.0)
+    velocity::NTuple{3, Float64} = (1.0,1.0,1.0)
+end
+
+@component struct Spring
+    center::NTuple{3, Float64}
+    spring_constant::Float64
+end
+
+@component struct Rotation
+	omega::Float64
+	center::NTuple{3, Float64}
+	axis::NTuple{3, Float64}
+	function Rotation()
+    	new(1.0, (2.0,2.0,2.0), (2.0,2.0,2.0))
+	end
+end
+
+struct Oscillator <: System end
+
+Overseer.requested_components(::Oscillator) = (Spatial, Spring)
+
+function Overseer.update(::Oscillator, m::AbstractLedger)
+	spatial = m[Spatial]
+	spring = m[Spring]
+	# g = group(m, Spatial, Spring)
+	@inbounds for e in @entities_in(spatial && spring)
+    	e_spat  = spatial[e]
+		spr     = spring[e]
+		v_prev  = e_spat.velocity 
+		new_v   = v_prev .- (e_spat.position .- spr.center) .* spr.spring_constant
+		spatial[e] = Spatial(e_spat.position, new_v)
+	end
+end
+
+struct Rotator <: System  end
+Overseer.requested_components(::Rotator) = (Spatial, Rotation)
+
+function Overseer.update(::Rotator, dio::AbstractLedger)
+	rotation  = dio[Rotation]
+	spatial   = dio[Spatial]
+	dt = 0.01
+	@inbounds for e in @entities_in(rotation && spatial) 
+    	e_rotation = rotation[e]
+    	e_spatial  = spatial[e]
+		n          = e_rotation.axis
+		r          = e_spatial.position .- e_rotation.center 
+		theta      = e_rotation.omega * dt
+		nnd        = n .* sum(n .* r)
+		t = (r[2] * n[3] - r[3] * n[2], r[3]*n[1] - r[1] * n[3] , r[1] * n[2] - r[2] * n[1])
+		spatial[e] = Spatial(e_rotation.center .+ nnd .+ (r .- nnd) .* cos(theta) .+ t .* sin(theta), e_spatial.velocity)
+	end
+end
+
+struct Mover <: System end
+
+Overseer.requested_components(::Mover) = (Spatial, )
+
+function Overseer.update(::Mover, m::AbstractLedger)
+    dt = 0.01
+    spat = m[Spatial]
+    @inbounds for e in @entities_in(spat)
+        e_spat = spat[e]
+        spat[e] = Spatial(e_spat.position .+ e_spat.velocity.*dt, e_spat.velocity)
+    end
+end
+
+
+suite = BenchmarkGroup()
+suite["creation"] = BenchmarkGroup()
+
+st = Stage(:simulation, [Oscillator(), Rotator(), Mover()])
+
+suite["creation"]["ledger"] = @benchmarkable m = Ledger($st)
+function e_fill(m)
+    for i=1:1000
+        e1 = Entity(m, 
+                    Spatial((i, 1.0, 1.0), (0.0, 0.0, 0.0)),
+                    Spring((1.0, 0.0, 0.0), 0.01))
+                   
+        e1 = Entity(m, 
+                    Spatial((i, 1.0, 1.0), (0.0, 0.0, 0.0)),
+                    Spring((1.0, 0.0, 0.0), 0.01),
+                    Rotation())
+                   
+    end
+end
+
+suite["creation"]["filling entities"] = @benchmarkable e_fill(m) setup=(m = Ledger(st))
+
+suite["update"] = BenchmarkGroup()
+
+suite["update"]["old school empty"] = @benchmarkable update(m) setup=(m = Ledger(st))
+suite["update"]["old school full"] = @benchmarkable update(m) setup=(m = Ledger(st); e_fill(m))
+
+function update_new(::Oscillator, m::AbstractLedger)
+	@inbounds for e in @entities_in(m, Spatial && Spring)
+		new_v   = e.velocity .- (e.position .- e[Spring].center) .* e.spring_constant
+		e[Spatial] = Spatial(e.position, new_v)
+	end
+end
+
+function update_new(::Rotator, m::AbstractLedger)
+	dt = 0.01
+	@inbounds for e in @entities_in(m, Rotation && Spatial) 
+		n          = e.axis
+		r          = e.position .- e[Rotation].center 
+		theta      = e.omega * dt
+		nnd        = n .* sum(n .* r)
+		t = (r[2] * n[3] - r[3] * n[2], r[3]*n[1] - r[1] * n[3] , r[1] * n[2] - r[2] * n[1])
+		e[Spatial] = Spatial(e[Rotation].center .+ nnd .+ (r .- nnd) .* cos(theta) .+ t .* sin(theta), e.velocity)
+	end
+end
+
+function update_new(::Mover, m::AbstractLedger)
+    dt = 0.01
+    @inbounds for e in @entities_in(m, Spatial)
+        e[Spatial] = Spatial(e.position .+ e.velocity.*dt, e.velocity)
+    end
+end
+
+suite["update"]["new school empty"] = @benchmarkable (update_new(Oscillator(), m);
+                                                      update_new(Rotator(), m);
+                                                      update_new(Mover(), m)) setup=(m = Ledger(st))
+suite["update"]["new school full"] = @benchmarkable (update_new(Oscillator(), m);
+                                                      update_new(Rotator(), m);
+                                                      update_new(Mover(), m)) setup=(m = Ledger(st); e_fill(m))
+
+results = run(suite)
+
+@show results
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,4 @@ using Overseer
 @testset "Indices" begin include("test_indices.jl") end
 @testset "Components" begin include("test_components.jl") end
 @testset "Ledger" begin include("test_ledger.jl") end
-
+@testset "Benchmark" begin include("benchmark.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using Overseer
 
-@testset "Indices" begin include("test_indices.jl") end
+@testset "Indices"    begin include("test_indices.jl")    end
 @testset "Components" begin include("test_components.jl") end
-@testset "Ledger" begin include("test_ledger.jl") end
-@testset "Benchmark" begin include("benchmark.jl") end
+@testset "Ledger"     begin include("test_ledger.jl")     end
+@testset "Benchmark"  begin include("benchmark.jl")       end

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -147,6 +147,6 @@ swap_order!(c3, Entity(12), Entity(13))
 
     iter = @entities_in(comp1 && comp2)
     es = collect(iter)
-    @test es == [e2]
-    @test eltype(es) == Entity
+    @test getfield.(es, :e) == [e2]
+    @test eltype(es) == Overseer.EntityState{Tuple{Ptr{Test1},Ptr{Test2}}}
 end

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -19,119 +19,152 @@ Test3() = Test3(1)
     p::Int = 1
 end
 
-@test Overseer.component_type(Test1) == Component
-@test Overseer.component_type(Test2) == Component
-@test Overseer.component_type(Test3) == SharedComponent
-@test Overseer.component_type(Test4) == SharedComponent
+const c1 = Overseer.component_type(Test1){Test1}()
+const c2 = Overseer.component_type(Test2){Test2}()
+const c3 = Overseer.component_type(Test3){Test3}()
+const c4 = Overseer.component_type(Test4){Test4}()
 
-c1 = Overseer.component_type(Test1){Test1}()
-c2 = Overseer.component_type(Test2){Test2}()
-c3 = Overseer.component_type(Test3){Test3}()
-c4 = Overseer.component_type(Test4){Test4}()
+const entities1 = [Entity(i) for i in 2:2:10]
+const entities2 = [Entity(i) for i in 10:3:20]
+const entities3 = [Entity(i) for i in 3:10]
+const entities4 = [Entity(1)]
 
-entities1 = [Entity(i) for i in 2:2:10]
-entities2 = [Entity(i) for i in 10:3:20]
-entities3 = [Entity(i) for i in 3:10]
-entities4 = [Entity(1)]
+@component struct ParametricComp{T}
+    x::T
+end
 
-for (c, es) in zip((c1, c2, c3, c4), (entities1, entities2, entities3, entities4))
-    for e in es
-        c[e] = eltype(c)()
+@component @with_kw struct ParametricCompKw{T}
+    x::T = 1.0
+end
+
+@component struct ParametricCompFunc{T}
+    x::T 
+    function ParametricCompFunc()
+        new{Float64}(1.0)
+    end
+    function ParametricCompFunc{T}() where {T}
+        new{T}(T(1.0))
     end
 end
 
-for (c, es) in zip((c1, c2, c3, c4), (entities1, entities2, entities3, entities4))
-    for e in es
-        @test in(e, c)
+@testset "Basic Component definitions" begin
+    @test Overseer.component_type(Test1) == Component
+    @test Overseer.component_type(Test2) == Component
+    @test Overseer.component_type(Test3) == SharedComponent
+    @test Overseer.component_type(Test4) == SharedComponent
+
+    for (c, es) in zip((c1, c2, c3, c4), (entities1, entities2, entities3, entities4))
+        for e in es
+            c[e] = eltype(c)()
+        end
     end
-end
 
-t = 0
-for e in @entities_in(((c1 && c3) || c4) && !c2)
-    global t += e.id
-end
-@test t == 4+6+8+1
-
-t = 0
-for e in @entities_in((c1 || c3) && !c2)
-    if e in c1
-        global t += e.id
+    for (c, es) in zip((c1, c2, c3, c4), (entities1, entities2, entities3, entities4))
+        for e in es
+            @test in(e, c)
+        end
     end
-    if e in c3
-        global t += c3[e].p
+
+    @test ParametricComp <: Overseer.ComponentData
+
+    @test ParametricCompKw <: Overseer.ComponentData
+    @test ParametricCompKw().x == 1.0
+    
+    @test ParametricCompFunc <: Overseer.ComponentData
+    @test ParametricCompFunc().x == 1.0
+    @test ParametricCompFunc{Int}().x === 1
+    
+end
+
+@testset "Component iteration" begin
+    t = 0
+    for e in @entities_in(((c1 && c3) || c4) && !c2)
+        t += e.id
     end
+    @test t == 4+6+8+1
+
+    t = 0
+    for e in @entities_in((c1 || c3) && !c2)
+        if e in c1
+            t += e.id
+        end
+        if e in c3
+            t += c3[e].p
+        end
+    end
+    @test t == 27
+
+    t = 0
+    for e in @entities_in(c1)
+        t += e.id
+    end
+    @test t == sum(2:2:10)
 end
-@test t == 27
 
-t = 0
-for e in @entities_in(c1)
-    global t += e.id
+@testset "Component and entity manipulation" begin
+    @test pop!(c1, Entity(10)) == Test1()
+
+    @test length(c1) == length(entities1) - 1
+
+    @test pop!(c2, Entity(10)) == Test2()
+
+    @test length(c2) == length(entities2) - 1
+    @test c1[1] == Test1()
+    @test c3[1] == Test3()
+
+    c2[Entity(13)] = Test2(50)
+    @test c2[Entity(13)] == Test2(50)
+
+    c3[Entity(13)] = Test3(50)
+    @test c3[Entity(13)] == Test3(50)
+
+    pop!(c3, Entity(13))
+    @test !in(Entity(13), c3)
+
+    empty!(c1)
+    @test isempty(c1)
+
+    empty!(c3)
+    @test isempty(c3)
+
+    # swap_ordering
+    c2[Entity(12)] = Test2()
+
+    @test_throws BoundsError swap_order!(c2, Entity(14), Entity(15))
+    @test_throws BoundsError swap_order!(c2, Entity(13), Entity(14))
+
+    orig1 = c2[Entity(12)]
+    orig2 = c2[Entity(13)]
+
+    orig_id1 = c2.indices[12]
+    orig_id2 = c2.indices[13]
+
+    swap_order!(c2, Entity(12), Entity(13))
+    @test c2[Entity(12)] == orig1
+    @test c2[Entity(13)] == orig2
+
+    @test c2.indices[13] == orig_id1
+    @test c2.indices[12] == orig_id2
+
+    c3[Entity(12)] = Test3()
+    c3[Entity(13)] = Test3(50)
+
+    @test_throws BoundsError swap_order!(c3, Entity(14), Entity(15))
+    @test_throws BoundsError swap_order!(c3, Entity(13), Entity(14))
+
+    orig1 = c3[Entity(12)]
+    orig2 = c3[Entity(13)]
+
+    orig_id1 = c3.indices[12]
+    orig_id2 = c3.indices[13]
+
+    swap_order!(c3, Entity(12), Entity(13))
+    @test c3[Entity(12)] == orig1
+    @test c3[Entity(13)] == orig2
+
+    @test c3.indices[13] == orig_id1
+    @test c3.indices[12] == orig_id2
 end
-@test t == sum(2:2:10)
-
-@test pop!(c1, Entity(10)) == Test1()
-
-@test length(c1) == length(entities1) - 1
-
-@test pop!(c2, Entity(10)) == Test2()
-
-@test length(c2) == length(entities2) - 1
-@test c1[1] == Test1()
-@test c3[1] == Test3()
-
-c2[Entity(13)] = Test2(50)
-@test c2[Entity(13)] == Test2(50)
-
-c3[Entity(13)] = Test3(50)
-@test c3[Entity(13)] == Test3(50)
-
-pop!(c3, Entity(13))
-@test !in(Entity(13), c3)
-
-empty!(c1)
-@test isempty(c1)
-
-empty!(c3)
-@test isempty(c3)
-
-
-# swap_ordering
-c2[Entity(12)] = Test2()
-
-@test_throws BoundsError swap_order!(c2, Entity(14), Entity(15))
-@test_throws BoundsError swap_order!(c2, Entity(13), Entity(14))
-
-orig1 = c2[Entity(12)]
-orig2 = c2[Entity(13)]
-
-orig_id1 = c2.indices[12]
-orig_id2 = c2.indices[13]
-
-swap_order!(c2, Entity(12), Entity(13))
-@test c2[Entity(12)] == orig1
-@test c2[Entity(13)] == orig2
-
-@test c2.indices[13] == orig_id1
-@test c2.indices[12] == orig_id2
-
-c3[Entity(12)] = Test3()
-c3[Entity(13)] = Test3(50)
-
-@test_throws BoundsError swap_order!(c3, Entity(14), Entity(15))
-@test_throws BoundsError swap_order!(c3, Entity(13), Entity(14))
-
-orig1 = c3[Entity(12)]
-orig2 = c3[Entity(13)]
-
-orig_id1 = c3.indices[12]
-orig_id2 = c3.indices[13]
-
-swap_order!(c3, Entity(12), Entity(13))
-@test c3[Entity(12)] == orig1
-@test c3[Entity(13)] == orig2
-
-@test c3.indices[13] == orig_id1
-@test c3.indices[12] == orig_id2
 
 # Issue 4: collect() and iterator length
 @testset "collect" begin

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -226,5 +226,5 @@ end
     iter = @entities_in(comp1 && comp2)
     es = collect(iter)
     @test getfield.(es, :e) == [e2]
-    @test eltype(es) == Overseer.EntityState{Tuple{Ptr{Test1},Ptr{Test2}}}
+    @test eltype(es) == Overseer.EntityState{Tuple{Component{Test1},Component{Test2}}}
 end

--- a/test/test_ledger.jl
+++ b/test/test_ledger.jl
@@ -159,11 +159,11 @@ t1[test_entity] = Test3()
 
 @test t1[test_entity] == (m[Test1][test_entity], m[Test2][test_entity], m[Test3][test_entity])
 
-tot = 0
-for e in @entities_in(group(m, Test1, Test2))
-    global tot += 1
-end
-@test tot == length(group(m, Test1, Test2))
+# tot = 0
+# for e in @entities_in(group(m, Test1, Test2))
+#     global tot += 1
+# end
+# @test tot == length(group(m, Test1, Test2))
 
 test_entity = entities(m)[end-1]
 m[test_entity] = Test3(test_entity.id)


### PR DESCRIPTION
The main goal of this implementation is to reduce some of the friction associated with iterating through entities based on #7.

The following relatively verbose syntax that was required in the past:
```julia
comp1 = ledger[Comp1]
comp2 = ledger[Comp2]
for e in @entites_in(comp1 && comp2)
    ... = comp1[e].xyz
    comp2[e] = Comp2(...)
end
```
is now replaced by
```julia
for e in @entities_in(ledger, Comp1 && Comp2)
    ... = e[Comp1].xyz
    e[Comp2] = Comp2(...)
end
```
This is facilitated by an `EntityState` struct that holds both the entity and pointers to the different components of it. 
Adding to a component that didn't have this particular `Entity` yet can be done equally as before by 
`comp3[e] = Comp3(...)` with `e::EntityState`.

The need for supporting `@entities_in(comp1 || comp2)` has required some checks on whether someone is trying to access invalid memory i.e. `e[Comp2]` if `!(e in comp2)`.
The check `e in comp2` is relatively fast since the pointer to `comp2` in `e` will be set to `Ptr{Comp2}()` if `!(e in comp2)`. 

This machinery adds about 8-9% slowdown to *ALL* iteration, making me question whether this is useful since `||` can be just done by a nested loop over the `||` Components.

If we really want to keep the `||` syntactic sugar, it would be possible to define 2 iterators, one that only has `&&` and doesn't need to checking machinery and is thus fast, and one that has `||`.

Finally, having played around with pointers, I think slight speedups could be gained by passing the `pointer` id's straight from the `IndicesIterator` so that one level of checking is removed, now it's done through `pointer(c::Component, e::Entity)` inside the iteration.

cheers! 