### PR TITLE
Grouped component

### DIFF
--- a/src/Overseer.jl
+++ b/src/Overseer.jl
@@ -24,7 +24,7 @@ module Overseer
     include("ledger.jl")
 
     export AbstractLedger, Ledger, System, Stage, Component, SharedComponent, ComponentData, Entity
-    export @component, @shared_component
+    export @component, @shared_component, @grouped_component
     export @entities_in
 
     export update, schedule_delete!, delete_scheduled!, empty_entities!, stage, components, entities, stages

--- a/src/entity.jl
+++ b/src/entity.jl
@@ -26,6 +26,19 @@ function Entity(c::AbstractComponent, i::Integer)
     return Entity(c.indices.packed[i])
 end
 
+function Entity(m::AbstractLedger, parent::Entity, datas::ComponentData...)
+	e = Entity(m)
+	for d in datas
+		m[e] = d
+	end
+	for (T, component) in components(m)
+		if component isa GroupedComponent && in(parent, component) && !in(e, component)
+			component[e] = parent
+		end
+	end
+	return e
+end
+
 Base.iterate(e::Entity, state=1) = state > 1 ? nothing : (e, state+1)
 
 const EMPTY_ENTITY = Entity(0)


### PR DESCRIPTION
I did a bit of performance checking and noticed that `SharedComponent` is comparable to `Component` in terms of speed when getting values but much slower when setting. I assumed this is mostly because the duplication check, so I tried making another component that does not do this.

So basically `GroupedComponent` is `SharedComponent` but without any check for duplication. The normal syntax of `component[entity] = value` will always store a new value and generate a new group. You can add an entity to that group via `component[entity] = parent_entity`, which is somewhat like inheritance. However there is no "parent" - removing an entity will only remove that entity and only clear the value if it's the last entity in its group.

I also added an `Entity(::AbstractLedger, parent::Entity, components...)` method which "inherits" all components from `parent`, with passed components taking priority. (I.e. if you pass a `Color` the new entity will have that color, not the one from the parent.)

My hope is that this will be helpful for entity collections with shared attributes. In the context of Makie, for example, transforming `scatter(rand(Point3f0, 1000), color = :red)` into 1000 entities, without duplicating the color 1000 times.