### PR TITLE
Reactive  Components

### DIFF
--- a/src/Overseer.jl
+++ b/src/Overseer.jl
@@ -24,6 +24,7 @@ module Overseer
     include("group.jl")
     include("system.jl")
     include("ledger.jl")
+    include("reactive.jl")
 
     export AbstractLedger, Ledger, System, Stage, Component, SharedComponent, GroupedComponent, ComponentData, Entity
     export @component, @shared_component, @grouped_component

--- a/src/reactive.jl
+++ b/src/reactive.jl
@@ -1,0 +1,74 @@
+mutable struct ReactiveComponent{T, C<:AbstractComponent} <: AbstractComponent{T}
+    component::C
+    changed::Bool
+end
+ReactiveComponent{T}() where {T <: ComponentData} = ReactiveComponent{T, Component{T}}(Component{T}(), false)
+
+macro reactive_component(typedef)
+    return esc(Overseer._reactive_component(typedef, __module__))
+end
+
+function _reactive_component(typedef, mod)
+    t = process_typedef(typedef, mod)
+    t1, tn = t 
+    return quote
+        $t1
+       	Overseer.component_type(::Type{$tn}) = Overseer.ReactiveComponent
+    end
+end
+
+function Base.getproperty(c::ReactiveComponent, f::Symbol)
+    if f == :component
+        return getfield(c, :component)
+    elseif f == :changed
+        return getfield(c, :changed)
+    else
+        return getproperty(c.component, f)
+    end
+end
+
+# Base mutating functions 
+for f in (:delete!, :permute!, :setindex!, :empty!, :pop!)
+    @eval function Base.$f(c::ReactiveComponent, args...)
+        c.changed = true
+        $f(c.component, args...)
+    end
+end
+
+# Overseer mutating functions
+for f in (:swap_order!, :pop_indices_data!, :ensure_entity_id!)
+    @eval function $f(c::ReactiveComponent, args...)
+        c.changed = true
+        $f(c.component, args...)
+    end
+end
+
+# Base non-mutating
+for f in (:getindex, :pointer, :iterate, :sortperm, :eltype)
+    @eval Base.$f(c::ReactiveComponent, args...) = $f(c.component, args...)
+end    
+
+function update_reactive(l::AbstractLedger)
+    changed_comps = filter(x -> x isa ReactiveComponent && x.changed, collect(values(components(l))))
+    if isempty(changed_comps)
+        return
+    end
+    types = eltype.(changed_comps)
+    systems_to_update = System[]
+    for stage in stages(l)
+        for sys in stage[2]
+            if any(x -> x ∈ in_components(sys), types)
+                push!(systems_to_update, sys)
+            end
+        end
+    end
+    for sys in systems_to_update
+        update(sys, l)
+    end
+    for c in changed_comps
+        c.changed = false
+    end
+
+    # Now recurse for possible updated components
+    update_reactive(l)
+end

--- a/src/system.jl
+++ b/src/system.jl
@@ -1,6 +1,7 @@
 update(::S, m::AbstractLedger) where {S<:System}= error("No update method implemented for $S")
 
 requested_components(::System) = ()
+in_components(::System) = ()
 
 const Stage = Pair{Symbol, Vector{System}}
 


### PR DESCRIPTION
This is a trial at integrating some kind of reactivity into the current ECS framework.

As discussed in #11 there are a couple of ways to implement this. For now I've chosen to go for the change tracking component idea. I.e. upon any mutating operation performed, the flag `changed` will be put to `true`. In combination with the `in_components` function that `Systems` can define, upon calling `update_reactive(ledger)`, all changed components will be found, and the systems which have them as `in_components` will be updated in the same order as they were specified in the `ledger`.
This will be done recursively so that any updates will flow through the systems pipeline (if I didn't make mistakes).

Couple further thoughts:
- As discussed before, this would mean that a change to a single entity will trigger the system to process the entire component. The question is whether this does not fly in the face of the cases when Reactivity is useful such as plotting, when relatively little amount of entities are changed. 
- It would be possible to extend this with an `entity` buffer that tracks which `Entities` have actually been changed, which could then be used in the "reactive" system through `@changed_entities`. I think this would be an elegant and flexible way to solve the Reactivity, while still being true to the ECS philosophy (system acting on components rather than single entities).

Pinging @ffreyer for some more input on this. Let me know what you think!

Cheers


 